### PR TITLE
Add compressionType option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ const installer = require('electron-installer-debian')
 const options = {
   src: 'dist/app-linux-x64/',
   dest: 'dist/installers/',
-  arch: 'amd64'
+  arch: 'amd64',
+  compressionType: 'xz'
 }
 
 async function main (options) {
@@ -179,7 +180,7 @@ async function main (options) {
 main(options)
 ```
 
-You'll end up with the package at `dist/installers/app_0.0.1_amd64.deb`.
+You'll end up with the package at `dist/installers/app_0.0.1_amd64.deb`, compressed with the `.xz` format.
 
 _Note: As of 1.0.0, the Node-style callback pattern is no longer available. You can use
 [`util.callbackify`](https://nodejs.org/api/util.html#util_util_callbackify_original) if this is
@@ -198,7 +199,8 @@ Even though you can pass most of these options through the command-line interfac
   ],
   "lintianOverrides": [
     "changelog-file-missing-in-native-package"
-  ]
+  ],
+  "compressionType": "xz"
 }
 ```
 
@@ -404,6 +406,12 @@ Type: `Array[String]`
 Default: `[]`
 
 You can use these to quieten [`lintian`](https://lintian.debian.org/manual/).
+
+#### options.compressionType
+Type: `String`
+Default: `xz`
+
+The compression algorithm to use for the packaged `.deb`, this can be any [supported algorithm](https://wiki.debian.org/Teams/Dpkg/DebSupport) by the `dpkg-deb` utility.
 
 #### options.scripts
 Type: `Object[String:String]`

--- a/example/config.json
+++ b/example/config.json
@@ -23,5 +23,6 @@
   ],
   "lintianOverrides": [
     "changelog-file-missing-in-native-package"
-  ]
+  ],
+  "compressionType": "xz"
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,6 +33,7 @@ const argv = yargs
   .options('options.categories', { array: true, hidden: true })
   .options('options.mimeType', { array: true, hidden: true })
   .options('options.lintianOverrides', { array: true, hidden: true })
+  .options('options.compressionType', { string: true, hidden: true })
   .example('$0 --src dist/app/ --dest dist/installer/ --arch i386', 'use metadata from `dist/app/`')
   .example('$0 --src dist/app/ --dest dist/installer/ --config config.json', 'use metadata from `config.json`')
   .wrap(null)

--- a/src/installer.js
+++ b/src/installer.js
@@ -111,7 +111,7 @@ class DebianInstaller extends common.ElectronInstaller {
   async createPackage () {
     this.options.logger(`Creating package at ${this.stagingDir}`)
 
-    const command = ['--build', this.stagingDir]
+    const command = ['--build', '-Z' + this.options.compressionType, this.stagingDir]
     if (process.platform === 'darwin') {
       command.unshift('--root-owner-group')
     }
@@ -142,7 +142,8 @@ class DebianInstaller extends common.ElectronInstaller {
       maintainer: this.getMaintainer(pkg.author),
 
       icon: path.resolve(__dirname, '../resources/icon.png'),
-      lintianOverrides: []
+      lintianOverrides: [],
+      compressionType: 'xz'
     }, debianDependencies.forElectron(electronVersion))
 
     return this.defaults


### PR DESCRIPTION
Self-explanatory really! This PR adds the `options.compressionType` property which adjusts the compression parameter which is passed to `dpkg-deb`.